### PR TITLE
Update sync.sh

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -17,4 +17,4 @@ git commit -m "Updated"
 
 # Push changes to remote repository on branch 'main'
 
-git push origin main
+git push 


### PR DESCRIPTION
This pull request includes a small change to the `sync.sh` file. The change removes the branch specification from the `git push` command, allowing it to push to the current branch by default.